### PR TITLE
fix(events): now emiting $scope events rather than DOM events

### DIFF
--- a/template/comments/comment.html
+++ b/template/comments/comment.html
@@ -6,7 +6,8 @@
       <span class="comment-username" ng-if="!comment.profileUrl">{{comment.name}}</span>
       <span class="comment-date" ng-if="comment.date">{{comment.date}}</span>
   </div>
-  <div class="comment-body" ng-bind="comment.text">
-      <child-comments comment-data="comment.children"></child-comments>
+  <div class="comment-body">
+    <div ng-bind="comment.text"></div>
+    <div comments-transclude comment-data="comment.children"></div>
   </div>
 </div>


### PR DESCRIPTION
Due to some issues, I've decided to emit angular $scope events rather than 
using $.triggerHandler. The reason for this is primarily to fit in more 
closely with Angular, and to avoid some of the undocumented weirdness which 
jQuery performs. (jQuery undecorates jq elements, though jqlite does not).

BREAKING CHANGE:

Rather than binding `$element.bind('filled.comments', fn)`, one must instead
`$scope.$on('$filledNestedComments', fn)` and expect a jQuery/jqLite element, 
which is either the comment element itself (if there is no commentsTransclude 
in use), or the commentsTransclude element (or the comments collection which 
replaces it) if it is present.

Similarly, `$element.bind('emptied.comments', fn)` must instead be written as
`$scope.$on('$emptiedNestedComments', fn)`. The same parameter rules as above 
apply.

The event names are not yet final, and will likely be broken again in the
near future.
